### PR TITLE
pr_checkout: add support for checking out GitHub links to pull requests 

### DIFF
--- a/pr_checkout
+++ b/pr_checkout
@@ -17,7 +17,7 @@ MASTER="${MASTER:-master}"
 cd "$DIR"
 
 # delete existing branch
-git checkout "$MASTER"
+git checkout -q "$MASTER"
 git fetch "$UPSTREAM"
 git branch -D "pr/$PR" || true 2> /dev/null
 git fetch "$UPSTREAM" "refs/pull/$PR/head:pr/$PR"

--- a/pr_checkout
+++ b/pr_checkout
@@ -1,7 +1,16 @@
 #!/bin/bash
 # Checkout a PR to an upstream repo from the CLI
 # This will overwrite previous checkouts
-# use: pr_checkout 5040
+#
+# Examples:
+#
+# * (default, dir is pwd) checkout PR #5040, assuming that we're in a repo whose remote
+#   $UPSTREAM points to a GitHub repo that has a pull requst #5040 opened:
+# $ pr_checkout 5040
+#
+# * (explicit dir setting) checkout PR #5040 in /tmp/code/dmd (existing repo):
+# $ env DIR=/tmp/code/dmd pr_checkout 5040
+
 set -ueo pipefail
 
 if [ -z "${1+x}" ] ; then

--- a/pr_checkout
+++ b/pr_checkout
@@ -18,7 +18,5 @@ cd "$DIR"
 
 # delete existing branch
 git checkout -q "$MASTER"
-git fetch --prune "$UPSTREAM"
-git branch -D "pr/$PR" 2>/dev/null || true
-git fetch "$UPSTREAM" "refs/pull/$PR/head:pr/$PR"
+git fetch --prune "$UPSTREAM" "+refs/pull/$PR/head:pr/$PR"
 git checkout "pr/$PR"

--- a/pr_checkout
+++ b/pr_checkout
@@ -9,7 +9,7 @@ if [ -z "${1+x}" ] ; then
     exit
 fi
 
-DIR="$(pwd)"
+DIR=$(test -d ${DIR:-.} && cd ${DIR:-.} || true && pwd)
 PR="$1"
 UPSTREAM="${UPSTREAM:-upstream}"
 MASTER="${MASTER:-master}"

--- a/pr_checkout
+++ b/pr_checkout
@@ -19,6 +19,6 @@ cd "$DIR"
 # delete existing branch
 git checkout -q "$MASTER"
 git fetch --prune "$UPSTREAM"
-git branch -D "pr/$PR" || true 2> /dev/null
+git branch -D "pr/$PR" 2>/dev/null || true
 git fetch "$UPSTREAM" "refs/pull/$PR/head:pr/$PR"
 git checkout "pr/$PR"

--- a/pr_checkout
+++ b/pr_checkout
@@ -18,5 +18,6 @@ cd "$DIR"
 
 # delete existing branch
 git checkout -q "$MASTER"
-git fetch --prune "$UPSTREAM" "+refs/pull/$PR/head:pr/$PR"
+git fetch --prune "$UPSTREAM" "$MASTER" "+refs/pull/$PR/head:pr/$PR"
+git merge --ff-only "$UPSTREAM/$MASTER"
 git checkout "pr/$PR"

--- a/pr_checkout
+++ b/pr_checkout
@@ -18,7 +18,7 @@ cd "$DIR"
 
 # delete existing branch
 git checkout -q "$MASTER"
-git fetch "$UPSTREAM"
+git fetch --prune "$UPSTREAM"
 git branch -D "pr/$PR" || true 2> /dev/null
 git fetch "$UPSTREAM" "refs/pull/$PR/head:pr/$PR"
 git checkout "pr/$PR"

--- a/pr_checkout
+++ b/pr_checkout
@@ -14,19 +14,72 @@
 set -ueo pipefail
 
 if [ -z "${1+x}" ] ; then
-    echo "Usage: ./pr_checkout <123>"
+    echo "[!] Usage: ./pr_checkout <number>"
     exit
 fi
 
 DIR=$(test -d ${DIR:-.} && cd ${DIR:-.} || true && pwd)
-PR="$1"
 UPSTREAM="${UPSTREAM:-upstream}"
 MASTER="${MASTER:-master}"
 
+function prompt {
+    while true; do
+        read -p "$1" choice
+        case "$choice" in
+            y|Y|'') return 0;;
+            n|N) return 1;;
+            *) ;;
+        esac
+    done
+}
+
+function is_git_repo {
+    dir=$1; user=${2:-}; repo=${3:-}; upstream=${4:-};
+    if ! git -C $dir rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        return 1;
+    fi
+    if ! test -z "$user" || ! test -z "$repo" || ! test -z $upstream; then
+        repo_regex="^${upstream:-.*}[[:space:]]*\
+((https://github\.com/)|(git@github\.com:))${user:-.*}/${repo:-.*}(\.git)?"
+        git -C $dir remote -v | grep -qE "$repo_regex"
+    else
+        return 0
+    fi
+}
+
+function is_repo_clean { git -C $1 diff-index --quiet HEAD --; }
+
+function git_stash_if_needed {
+    if ! is_repo_clean $1; then
+        echo "[!] Repo '$1' contains uncommited changes."
+        if ! prompt "[?] Stash uncommitted changes [Y/n]? "; then
+            echo "[!] Unable to proceed. Good bye."; exit 1
+        fi
+        git -C $1 stash push
+    fi
+}
+
+echo "[>] Executing from '$DIR'."
+
 cd "$DIR"
+pr_num_regex='^([0-9]+)$'
+input=$1
+if [[ $input =~ $pr_num_regex ]]; then
+    PR="${BASH_REMATCH[1]}"
+    if ! is_git_repo $DIR '' '' $UPSTREAM; then
+        echo "[!] Dir '$DIR' is not a valid git repo."
+        exit 1
+    fi
+
+    git_stash_if_needed $DIR
+    echo "[>] Attempting to fetch PR #$PR from '$UPSTREAM' ($(git remote get-url $UPSTREAM))."
+else
+    echo "[!] '$input' is not a valid number."
+    exit 1
+fi
 
 # delete existing branch
 git checkout -q "$MASTER"
 git fetch --prune "$UPSTREAM" "$MASTER" "+refs/pull/$PR/head:pr/$PR"
-git merge --ff-only "$UPSTREAM/$MASTER"
+echo -n "[>] Fast-forwarding '$MASTER' branch... "; git merge --ff-only "$UPSTREAM/$MASTER"
 git checkout "pr/$PR"

--- a/pr_checkout
+++ b/pr_checkout
@@ -10,11 +10,29 @@
 #
 # * (explicit dir setting) checkout PR #5040 in /tmp/code/dmd (existing repo):
 # $ env DIR=/tmp/code/dmd pr_checkout 5040
+#
+# * (checkout URL) if the current dir is repo, checkout PR #1234. Otherwise clone
+#   the repo and then checkout the PR:
+# $ pr_checkout https://github.com/dlang/dmd/pull/1234
+#
+# * Supports copy-pasting various valid links to a pull-requests:
+# $ pr_checkout http://www.github.com/dlang/dmd/pull/1234
+# $ pr_checkout https://github.com/dlang/dmd/pull/1234/commits
+# $ pr_checkout https://github.com/dlang/dmd/pull/1234/checks
+# $ pr_checkout https://github.com/dlang/dmd/pull/1234/files
+# $ pr_checkout https://github.com/dlang/dmd/pull/9195#issuecomment-451495487
+#
+# * And even droping the obvious part of the url:
+# $ pr_checkout dlang/dmd/pull/1234
+#
+# * Use the DIR and UPSTREAM env variables to override the working directory
+#   as well as the name of the "upstream" remote:
+# $ env DIR=./dmd UPSTREAM=origin pr_checkout dlang/dmd/pull/6789
 
 set -ueo pipefail
 
 if [ -z "${1+x}" ] ; then
-    echo "[!] Usage: ./pr_checkout <number>"
+    echo "[!] Usage: ./pr_checkout <number>|<https://github.com/<user>/<repo>/pull/<number>>"
     exit
 fi
 
@@ -63,6 +81,7 @@ echo "[>] Executing from '$DIR'."
 
 cd "$DIR"
 pr_num_regex='^([0-9]+)$'
+pr_url_regex='^(https?://(www\.)?github\.com/)?(.+)/(.+)/pull/([0-9]+)([/#].*)?$'
 input=$1
 if [[ $input =~ $pr_num_regex ]]; then
     PR="${BASH_REMATCH[1]}"
@@ -73,8 +92,27 @@ if [[ $input =~ $pr_num_regex ]]; then
 
     git_stash_if_needed $DIR
     echo "[>] Attempting to fetch PR #$PR from '$UPSTREAM' ($(git remote get-url $UPSTREAM))."
+
+elif [[ $input =~ $pr_url_regex ]]; then
+    user="${BASH_REMATCH[3]}"
+    repo="${BASH_REMATCH[4]}"
+    PR="${BASH_REMATCH[5]}"
+
+    echo "[>] Attempting to fetch PR #$PR from 'github.com/$user/$repo'."
+
+    if ! is_git_repo $DIR $user $repo "$UPSTREAM"; then
+        echo "[!] Dir '$DIR' is not a valid git clone of '$user/$repo'."
+        if ! prompt "[?] Clone to '$DIR/$repo' [Y/n]? "; then
+            echo "[!] Clone aborted. Good bye."; exit 1
+        fi
+        git clone --depth 1 "https://github.com/$user/$repo" "$DIR/$repo"
+        cd "$DIR/$repo"
+        git remote rename origin $UPSTREAM 2>/dev/null || true
+    else
+        git_stash_if_needed $DIR
+    fi
 else
-    echo "[!] '$input' is not a valid number."
+    echo "[!] '$input' is neither a valid number, nor a valid URL to a GitHub pull request."
     exit 1
 fi
 


### PR DESCRIPTION
And various other improvements. See the individual commits for details ;)


TL;DR;

```
$ pr_checkout wilzbach/git-tools/pull/2
[>] Executing from '/home/zlx/code/repos'.
[>] Attempting to fetch PR #2 from 'github.com/wilzbach/git-tools'.
[!] Dir '/home/zlx/code/repos' is not a valid git clone of 'wilzbach/git-tools'.
[?] Clone to '/home/zlx/code/repos/git-tools' [Y/n]? y
Cloning into '/home/zlx/code/repos/git-tools'...
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 9 (delta 0), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (9/9), done.
remote: Enumerating objects: 29, done.
remote: Counting objects: 100% (29/29), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 27 (delta 17), reused 26 (delta 16), pack-reused 0
Unpacking objects: 100% (27/27), done.
From https://github.com/wilzbach/git-tools
 * branch            master           -> FETCH_HEAD
 * [new ref]         refs/pull/2/head -> pr/2
[>] Fast-forwarding 'master' branch... Already up to date.
Switched to branch 'pr/2'
```

```
$ env DIR=./wilzbach/git-tools/ pr_checkout https://github.com/wilzbach/git-tools/pull/2/files
[>] Executing from '/home/zlx/code/repos/wilzbach/git-tools'.
[>] Attempting to fetch PR #2 from 'github.com/wilzbach/git-tools'.
From https://github.com/wilzbach/git-tools
 * branch            master     -> FETCH_HEAD
[>] Fast-forwarding 'master' branch... Already up to date.
Switched to branch 'pr/2'
```

```
env DIR=. ./wilzbach/git-tools/pr_checkout wilzbach/git-tools/pull/2/commits
[>] Executing from '/home/zlx/code/repos'.
[>] Attempting to fetch PR #2 from 'github.com/wilzbach/git-tools'.
[!] Dir '/home/zlx/code/repos' is not a valid git clone of 'wilzbach/git-tools'.
[?] Clone to '/home/zlx/code/repos/git-tools' [Y/n]? y
Cloning into '/home/zlx/code/repos/git-tools'...
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 9 (delta 0), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (9/9), done.
remote: Enumerating objects: 29, done.
remote: Counting objects: 100% (29/29), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 27 (delta 17), reused 26 (delta 16), pack-reused 0
Unpacking objects: 100% (27/27), done.
From https://github.com/wilzbach/git-tools
 * branch            master           -> FETCH_HEAD
 * [new ref]         refs/pull/2/head -> pr/2
[>] Fast-forwarding 'master' branch... Already up to date.
Switched to branch 'pr/2'
```

```
$ echo asd >> ./git-tools/README.md
$ env DIR=./git-tools/ ./wilzbach/git-tools/pr_checkout 2
[>] Executing from '/home/zlx/code/repos/git-tools'.
[!] Repo '/home/zlx/code/repos/git-tools' contains uncommited changes.
[?] Stash uncommitted changes [Y/n]? y
Saved working directory and index state WIP on pr/2: 29934f2 pr_checkout: add support for cloning PR URLs
[>] Attempting to fetch PR #2 from 'upstream' (https://github.com/wilzbach/git-tools).
From https://github.com/wilzbach/git-tools
 * branch            master     -> FETCH_HEAD
[>] Fast-forwarding 'master' branch... Already up to date.
Switched to branch 'pr/2'