### PR TITLE
Make scripts a bit more portable

### DIFF
--- a/merge_stable
+++ b/merge_stable
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Merges upstream/stable into upstream/master
 # Execute from any git repository or pass the directory as first argument
 

--- a/pr_checkout
+++ b/pr_checkout
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Checkout a PR to an upstream repo from the CLI
 # This will overwrite previous checkouts
 #

--- a/pr_push
+++ b/pr_push
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Force-push to a remote PR
 # Execute from any git repository or pass the directory as first argument
 

--- a/pr_send
+++ b/pr_send
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Submit a PR to an upstream repo from the CLI
 # Execute from any git repository or pass the directory as first argument
 set -ueo pipefail

--- a/pr_split
+++ b/pr_split
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This will submit all your changes in a separate PR for each file.
 #


### PR DESCRIPTION
By using `#!/usr/bin/env bash`, instead of `#!/bin/bash`, as bash can be
still be available, but installed to a different location. This is
especially true on distros such as NixOS, where FHS incompatability
is a feature and an explicit goal.